### PR TITLE
Add a Version class for transaction constants

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -4,22 +4,60 @@ declare(strict_types=1);
 
 namespace pxgamer\Arionum;
 
+use pxgamer\Arionum\Transaction\Version;
+
 final class Transaction
 {
-    /** @var int The transaction version for sending to an address. */
-    public const VERSION_STANDARD = 1;
-    /** @var int The transaction version for sending to an alias. */
-    public const VERSION_ALIAS_SEND = 2;
-    /** @var int The transaction version for setting an alias. */
-    public const VERSION_ALIAS_SET = 3;
-    /** @var int The transaction version for creating a masternode. */
-    public const VERSION_MASTERNODE_CREATE = 100;
-    /** @var int The transaction version for pausing a masternode. */
-    public const VERSION_MASTERNODE_PAUSE = 101;
-    /** @var int The transaction version for resuming a masternode. */
-    public const VERSION_MASTERNODE_RESUME = 102;
-    /** @var int The transaction version for releasing a masternode. */
-    public const VERSION_MASTERNODE_RELEASE = 103;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::STANDARD
+     * The transaction version for sending to an address.
+     */
+    public const VERSION_STANDARD = Version::STANDARD;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::ALIAS_SEND
+     * The transaction version for sending to an alias.
+     */
+    public const VERSION_ALIAS_SEND = Version::ALIAS_SEND;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::ALIAS_SET
+     * The transaction version for setting an alias.
+     */
+    public const VERSION_ALIAS_SET = Version::ALIAS_SET;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::MASTERNODE_CREATE
+     * The transaction version for creating a masternode.
+     */
+    public const VERSION_MASTERNODE_CREATE = Version::MASTERNODE_CREATE;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::MASTERNODE_PAUSE
+     * The transaction version for pausing a masternode.
+     */
+    public const VERSION_MASTERNODE_PAUSE = Version::MASTERNODE_PAUSE;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::MASTERNODE_RESUME
+     * The transaction version for resuming a masternode.
+     */
+    public const VERSION_MASTERNODE_RESUME = Version::MASTERNODE_RESUME;
+    /**
+     * @var int
+     * @deprecated
+     * @see Version::MASTERNODE_RELEASE
+     * The transaction version for releasing a masternode.
+     */
+    public const VERSION_MASTERNODE_RELEASE = Version::MASTERNODE_RELEASE;
+
     /** @var int The default value for masternode commands. */
     public const VALUE_MASTERNODE_COMMAND = 0.00000001;
     /** @var int The default fee for masternode commands. */
@@ -80,22 +118,22 @@ final class Transaction
      * The version of the transaction.
      * @var int
      */
-    public $version = self::VERSION_STANDARD;
+    public $version = Version::STANDARD;
 
     /**
      * Retrieve a pre-populated Transaction instance for sending to an alias.
      *
-     * @api
      * @param string $alias
      * @param float  $value
      * @param string $message
      * @return self
+     * @api
      */
     public static function makeAliasSendInstance(string $alias, float $value, string $message = ''): self
     {
         $transaction = new self();
 
-        $transaction->setVersion(self::VERSION_ALIAS_SEND);
+        $transaction->setVersion(Version::ALIAS_SEND);
         $transaction->setDestinationAddress($alias);
         $transaction->setValue($value);
         $transaction->setMessage($message);
@@ -106,16 +144,16 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for setting an alias.
      *
-     * @api
      * @param string $address
      * @param string $alias
      * @return self
+     * @api
      */
     public static function makeAliasSetInstance(string $address, string $alias): self
     {
         $transaction = new self();
 
-        $transaction->setVersion(self::VERSION_ALIAS_SET);
+        $transaction->setVersion(Version::ALIAS_SET);
         $transaction->setDestinationAddress($address);
         $transaction->setValue(self::VALUE_ALIAS_SET);
         $transaction->setFee(self::FEE_ALIAS_SET);
@@ -127,16 +165,16 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for creating a masternode.
      *
-     * @api
      * @param string $ipAddress
      * @param string $address
      * @return self
+     * @api
      */
     public static function makeMasternodeCreateInstance(string $ipAddress, string $address): self
     {
         $transaction = new self();
 
-        $transaction->setVersion(self::VERSION_MASTERNODE_CREATE);
+        $transaction->setVersion(Version::MASTERNODE_CREATE);
         $transaction->setDestinationAddress($address);
         $transaction->setValue(self::VALUE_MASTERNODE_CREATE);
         $transaction->setFee(self::FEE_MASTERNODE_CREATE);
@@ -148,45 +186,45 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for pausing a masternode.
      *
-     * @api
      * @param string $address
      * @return self
+     * @api
      */
     public static function makeMasternodePauseInstance(string $address): self
     {
         $transaction = new self();
 
-        $transaction->setVersion(self::VERSION_MASTERNODE_PAUSE);
+        $transaction->setVersion(Version::MASTERNODE_PAUSE);
         return self::setMasternodeCommandDefaults($address, $transaction);
     }
 
     /**
      * Retrieve a pre-populated Transaction instance for resuming a masternode.
      *
-     * @api
      * @param string $address
      * @return self
+     * @api
      */
     public static function makeMasternodeResumeInstance(string $address): self
     {
         $transaction = new self();
 
-        $transaction->setVersion(self::VERSION_MASTERNODE_RESUME);
+        $transaction->setVersion(Version::MASTERNODE_RESUME);
         return self::setMasternodeCommandDefaults($address, $transaction);
     }
 
     /**
      * Retrieve a pre-populated Transaction instance for releasing a masternode.
      *
-     * @api
      * @param string $address
      * @return self
+     * @api
      */
     public static function makeMasternodeReleaseInstance(string $address): self
     {
         $transaction = new self();
 
-        $transaction->setVersion(self::VERSION_MASTERNODE_RELEASE);
+        $transaction->setVersion(Version::MASTERNODE_RELEASE);
         return self::setMasternodeCommandDefaults($address, $transaction);
     }
 
@@ -292,10 +330,10 @@ final class Transaction
     /**
      * Set the default fee and value for masternode commands.
      *
-     * @internal
      * @param string $address
      * @param self   $transaction
      * @return self
+     * @internal
      */
     private static function setMasternodeCommandDefaults(string $address, Transaction $transaction): self
     {

--- a/src/Transaction/Version.php
+++ b/src/Transaction/Version.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace pxgamer\Arionum\Transaction;
+
+final class Version
+{
+    /** @var int The transaction version for sending to an address. */
+    public const STANDARD = 1;
+    /** @var int The transaction version for sending to an alias. */
+    public const ALIAS_SEND = 2;
+    /** @var int The transaction version for setting an alias. */
+    public const ALIAS_SET = 3;
+
+    /** @var int The transaction version for creating an asset. */
+    public const ASSET_CREATE = 50;
+    /** @var int The transaction version for sending units of an asset. */
+    public const ASSET_SEND = 51;
+    /** @var int The transaction version for creating a market ask/bid order for an asset. */
+    public const ASSET_MARKET = 52;
+    /** @var int The transaction version for cancelling a market order for an asset. */
+    public const ASSET_CANCEL_ORDER = 53;
+    /** @var int The transaction version for distributing dividends for an asset. */
+    public const ASSET_DIVIDENDS = 54;
+    /** @var int The transaction version for increasing the max supply of an asset. */
+    public const ASSET_INFLATE = 55;
+
+    /** @var int The transaction version for creating a masternode. */
+    public const MASTERNODE_CREATE = 100;
+    /** @var int The transaction version for pausing a masternode. */
+    public const MASTERNODE_PAUSE = 101;
+    /** @var int The transaction version for resuming a masternode. */
+    public const MASTERNODE_RESUME = 102;
+    /** @var int The transaction version for releasing a masternode. */
+    public const MASTERNODE_RELEASE = 103;
+}

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace pxgamer\Arionum;
 
+use pxgamer\Arionum\Transaction\Version;
+
 final class TransactionTest extends TestCase
 {
     // phpcs:disable Generic.Files.LineLength
@@ -43,7 +45,7 @@ final class TransactionTest extends TestCase
         $data = Transaction::makeAliasSendInstance(self::TEST_ALIAS, 1.0);
         $this->assertEquals(self::TEST_ALIAS, $data->dst);
         $this->assertEquals(1.0, $data->val);
-        $this->assertEquals(Transaction::VERSION_ALIAS_SEND, $data->version);
+        $this->assertEquals(Version::ALIAS_SEND, $data->version);
     }
 
     /**
@@ -55,7 +57,7 @@ final class TransactionTest extends TestCase
         $data = Transaction::makeAliasSetInstance(self::TEST_ADDRESS, self::TEST_ALIAS);
         $this->assertEquals(self::TEST_ADDRESS, $data->dst);
         $this->assertEquals(self::TEST_ALIAS, $data->message);
-        $this->assertEquals(Transaction::VERSION_ALIAS_SET, $data->version);
+        $this->assertEquals(Version::ALIAS_SET, $data->version);
         $this->assertEquals(Transaction::VALUE_ALIAS_SET, $data->val);
     }
 
@@ -68,7 +70,7 @@ final class TransactionTest extends TestCase
         $data = Transaction::makeMasternodeCreateInstance(self::TEST_IP, self::TEST_ADDRESS);
         $this->assertEquals(self::TEST_ADDRESS, $data->dst);
         $this->assertEquals(self::TEST_IP, $data->message);
-        $this->assertEquals(Transaction::VERSION_MASTERNODE_CREATE, $data->version);
+        $this->assertEquals(Version::MASTERNODE_CREATE, $data->version);
         $this->assertEquals(Transaction::VALUE_MASTERNODE_CREATE, $data->val);
         $this->assertEquals(Transaction::FEE_MASTERNODE_CREATE, $data->fee);
     }
@@ -81,7 +83,7 @@ final class TransactionTest extends TestCase
     {
         $data = Transaction::makeMasternodePauseInstance(self::TEST_ADDRESS);
         $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(Transaction::VERSION_MASTERNODE_PAUSE, $data->version);
+        $this->assertEquals(Version::MASTERNODE_PAUSE, $data->version);
         $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->val);
         $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->fee);
     }
@@ -94,7 +96,7 @@ final class TransactionTest extends TestCase
     {
         $data = Transaction::makeMasternodeResumeInstance(self::TEST_ADDRESS);
         $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(Transaction::VERSION_MASTERNODE_RESUME, $data->version);
+        $this->assertEquals(Version::MASTERNODE_RESUME, $data->version);
         $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->val);
         $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->fee);
     }
@@ -107,7 +109,7 @@ final class TransactionTest extends TestCase
     {
         $data = Transaction::makeMasternodeReleaseInstance(self::TEST_ADDRESS);
         $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(Transaction::VERSION_MASTERNODE_RELEASE, $data->version);
+        $this->assertEquals(Version::MASTERNODE_RELEASE, $data->version);
         $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->val);
         $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->fee);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a new [`Transaction\Version`](https://github.com/pxgamer/arionum-php/blob/301a4b23489c9ef658d4859b0eb308afcc90f3d4/src/Transaction/Version.php) class that registers constants. The previous version id constants have now been deprecated and will be removed in the next major version.

To prevent breaking changes, the old `Transaction` constants are currently now aliases of the new constants (as per commit caaac51dd1b802c3a4d7981b958216a2b05f4704).

All old constants have been marked with the following PHPDoc tags:
- `@deprecated` - This should trigger most PHP IDEs to mark the constant as deprecated.
- `@see Version::NEW_CONSTANT` - A reference to the new constant to use.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
