### PR TITLE
Add new accessor methods to replace public properties

### DIFF
--- a/src/Arionum.php
+++ b/src/Arionum.php
@@ -293,7 +293,7 @@ final class Arionum
      */
     public function sendTransaction(Transaction $transaction): string
     {
-        $data = array_merge((array) $transaction, [
+        $data = array_merge($transaction->toArray(), [
             'q' => 'send',
         ]);
 

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -453,6 +453,4 @@ final class Transaction
     {
         return $this->version;
     }
-
-
 }

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -82,24 +82,40 @@ final class Transaction
      * The value to send in the transaction.
      *
      * @var float
+     *
+     * @deprecated
+     *
+     * @see getValue()
      */
     public $val;
     /**
      * The fee for the transaction.
      *
      * @var float
+     *
+     * @deprecated
+     *
+     * @see getFee()
      */
     public $fee;
     /**
      * The destination address.
      *
      * @var string
+     *
+     * @deprecated
+     *
+     * @see getDestinationAddress()
      */
     public $dst;
     /**
      * The sender's public key.
      *
      * @var string
+     *
+     * @deprecated
+     *
+     * @see getPublicKey()
      */
     public $public_key;
     /**
@@ -107,12 +123,20 @@ final class Transaction
      * It's recommended that the transaction is signed to avoid sending your private key to the node.
      *
      * @var string
+     *
+     * @deprecated
+     *
+     * @see getSignature()
      */
     public $signature;
     /**
      * The sender's private key. Only required if no signature is provided.
      *
      * @var string
+     *
+     * @deprecated
+     *
+     * @see getPrivateKey()
      */
     public $private_key;
     /**
@@ -122,27 +146,39 @@ final class Transaction
      * @see https://epochconverter.com
      *
      * @var int
+     *
+     * @deprecated
+     *
+     * @see getDate()
      */
     public $date;
     /**
      * A message to be included with the transaction. Maximum 128 chars.
      *
      * @var string
+     *
+     * @deprecated
+     *
+     * @see getMessage()
      */
     public $message;
     /**
      * The version of the transaction.
      *
      * @var int
+     *
+     * @deprecated
+     *
+     * @see getVersion()
      */
     public $version = Version::STANDARD;
 
     /**
      * Retrieve a pre-populated Transaction instance for sending to an alias.
      *
-     * @param string $alias
-     * @param float  $value
-     * @param string $message
+     * @param  string  $alias
+     * @param  float  $value
+     * @param  string  $message
      *
      * @return self
      */
@@ -161,8 +197,8 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for setting an alias.
      *
-     * @param string $address
-     * @param string $alias
+     * @param  string  $address
+     * @param  string  $alias
      *
      * @return self
      */
@@ -182,8 +218,8 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for creating a masternode.
      *
-     * @param string $ipAddress
-     * @param string $address
+     * @param  string  $ipAddress
+     * @param  string  $address
      *
      * @return self
      */
@@ -203,7 +239,7 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for pausing a masternode.
      *
-     * @param string $address
+     * @param  string  $address
      *
      * @return self
      */
@@ -219,7 +255,7 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for resuming a masternode.
      *
-     * @param string $address
+     * @param  string  $address
      *
      * @return self
      */
@@ -235,7 +271,7 @@ final class Transaction
     /**
      * Retrieve a pre-populated Transaction instance for releasing a masternode.
      *
-     * @param string $address
+     * @param  string  $address
      *
      * @return self
      */
@@ -249,7 +285,7 @@ final class Transaction
     }
 
     /**
-     * @param float $value
+     * @param  float  $value
      *
      * @return $this
      */
@@ -261,7 +297,7 @@ final class Transaction
     }
 
     /**
-     * @param float $fee
+     * @param  float  $fee
      *
      * @return $this
      */
@@ -273,7 +309,7 @@ final class Transaction
     }
 
     /**
-     * @param string $destinationAddress
+     * @param  string  $destinationAddress
      *
      * @return $this
      */
@@ -285,7 +321,7 @@ final class Transaction
     }
 
     /**
-     * @param string $publicKey
+     * @param  string  $publicKey
      *
      * @return $this
      */
@@ -297,7 +333,7 @@ final class Transaction
     }
 
     /**
-     * @param string $signature
+     * @param  string  $signature
      *
      * @return $this
      */
@@ -309,7 +345,7 @@ final class Transaction
     }
 
     /**
-     * @param string $privateKey
+     * @param  string  $privateKey
      *
      * @return $this
      */
@@ -321,7 +357,7 @@ final class Transaction
     }
 
     /**
-     * @param int $date
+     * @param  int  $date
      *
      * @return $this
      */
@@ -333,7 +369,7 @@ final class Transaction
     }
 
     /**
-     * @param string $message
+     * @param  string  $message
      *
      * @return $this
      */
@@ -345,7 +381,7 @@ final class Transaction
     }
 
     /**
-     * @param int $version
+     * @param  int  $version
      *
      * @return $this
      */
@@ -359,8 +395,8 @@ final class Transaction
     /**
      * Set the default fee and value for masternode commands.
      *
-     * @param string $address
-     * @param self   $transaction
+     * @param  string  $address
+     * @param  self  $transaction
      *
      * @return self
      */

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -372,4 +372,51 @@ final class Transaction
 
         return $transaction;
     }
+
+    public function getValue(): float
+    {
+        return $this->val;
+    }
+
+    public function getFee(): float
+    {
+        return $this->fee;
+    }
+
+    public function getDestinationAddress(): string
+    {
+        return $this->dst;
+    }
+
+    public function getPublicKey(): string
+    {
+        return $this->public_key;
+    }
+
+    public function getSignature(): string
+    {
+        return $this->signature;
+    }
+
+    public function getPrivateKey(): string
+    {
+        return $this->private_key;
+    }
+
+    public function getDate(): int
+    {
+        return $this->date;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+
 }

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -429,12 +429,12 @@ final class Transaction
         return $this->public_key;
     }
 
-    public function getSignature(): string
+    public function getSignature(): ?string
     {
         return $this->signature;
     }
 
-    public function getPrivateKey(): string
+    public function getPrivateKey(): ?string
     {
         return $this->private_key;
     }
@@ -452,5 +452,20 @@ final class Transaction
     public function getVersion(): int
     {
         return $this->version;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'date' => $this->getDate(),
+            'dst' => $this->getDestinationAddress(),
+            'fee' => $this->getFee(),
+            'message' => $this->getMessage(),
+            'private_key' => $this->getPrivateKey(),
+            'public_key' => $this->getPublicKey(),
+            'signature' => $this->getSignature(),
+            'val' => $this->getValue(),
+            'version' => $this->getVersion(),
+        ];
     }
 }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -43,9 +43,9 @@ final class TransactionTest extends TestCase
     public function itCanGenerateAnAliasSendTransaction(): void
     {
         $data = Transaction::makeAliasSendInstance(self::TEST_ALIAS, 1.0);
-        $this->assertEquals(self::TEST_ALIAS, $data->dst);
-        $this->assertEquals(1.0, $data->val);
-        $this->assertEquals(Version::ALIAS_SEND, $data->version);
+        $this->assertEquals(self::TEST_ALIAS, $data->getDestinationAddress());
+        $this->assertEquals(1.0, $data->getValue());
+        $this->assertEquals(Version::ALIAS_SEND, $data->getVersion());
     }
 
     /**
@@ -55,10 +55,10 @@ final class TransactionTest extends TestCase
     public function itCanGenerateAnAliasSetTransaction(): void
     {
         $data = Transaction::makeAliasSetInstance(self::TEST_ADDRESS, self::TEST_ALIAS);
-        $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(self::TEST_ALIAS, $data->message);
-        $this->assertEquals(Version::ALIAS_SET, $data->version);
-        $this->assertEquals(Transaction::VALUE_ALIAS_SET, $data->val);
+        $this->assertEquals(self::TEST_ADDRESS, $data->getDestinationAddress());
+        $this->assertEquals(self::TEST_ALIAS, $data->getMessage());
+        $this->assertEquals(Version::ALIAS_SET, $data->getVersion());
+        $this->assertEquals(Transaction::VALUE_ALIAS_SET, $data->getValue());
     }
 
     /**
@@ -68,11 +68,11 @@ final class TransactionTest extends TestCase
     public function itCanGenerateAnMasternodeCreateTransaction(): void
     {
         $data = Transaction::makeMasternodeCreateInstance(self::TEST_IP, self::TEST_ADDRESS);
-        $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(self::TEST_IP, $data->message);
-        $this->assertEquals(Version::MASTERNODE_CREATE, $data->version);
-        $this->assertEquals(Transaction::VALUE_MASTERNODE_CREATE, $data->val);
-        $this->assertEquals(Transaction::FEE_MASTERNODE_CREATE, $data->fee);
+        $this->assertEquals(self::TEST_ADDRESS, $data->getDestinationAddress());
+        $this->assertEquals(self::TEST_IP, $data->getMessage());
+        $this->assertEquals(Version::MASTERNODE_CREATE, $data->getVersion());
+        $this->assertEquals(Transaction::VALUE_MASTERNODE_CREATE, $data->getValue());
+        $this->assertEquals(Transaction::FEE_MASTERNODE_CREATE, $data->getFee());
     }
 
     /**
@@ -82,10 +82,10 @@ final class TransactionTest extends TestCase
     public function itCanGenerateAnMasternodePauseTransaction(): void
     {
         $data = Transaction::makeMasternodePauseInstance(self::TEST_ADDRESS);
-        $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(Version::MASTERNODE_PAUSE, $data->version);
-        $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->val);
-        $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->fee);
+        $this->assertEquals(self::TEST_ADDRESS, $data->getDestinationAddress());
+        $this->assertEquals(Version::MASTERNODE_PAUSE, $data->getVersion());
+        $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->getValue());
+        $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->getFee());
     }
 
     /**
@@ -95,10 +95,10 @@ final class TransactionTest extends TestCase
     public function itCanGenerateAnMasternodeResumeTransaction(): void
     {
         $data = Transaction::makeMasternodeResumeInstance(self::TEST_ADDRESS);
-        $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(Version::MASTERNODE_RESUME, $data->version);
-        $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->val);
-        $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->fee);
+        $this->assertEquals(self::TEST_ADDRESS, $data->getDestinationAddress());
+        $this->assertEquals(Version::MASTERNODE_RESUME, $data->getVersion());
+        $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->getValue());
+        $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->getFee());
     }
 
     /**
@@ -108,9 +108,9 @@ final class TransactionTest extends TestCase
     public function itCanGenerateAnMasternodeReleaseTransaction(): void
     {
         $data = Transaction::makeMasternodeReleaseInstance(self::TEST_ADDRESS);
-        $this->assertEquals(self::TEST_ADDRESS, $data->dst);
-        $this->assertEquals(Version::MASTERNODE_RELEASE, $data->version);
-        $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->val);
-        $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->fee);
+        $this->assertEquals(self::TEST_ADDRESS, $data->getDestinationAddress());
+        $this->assertEquals(Version::MASTERNODE_RELEASE, $data->getVersion());
+        $this->assertEquals(Transaction::VALUE_MASTERNODE_COMMAND, $data->getValue());
+        $this->assertEquals(Transaction::FEE_MASTERNODE_COMMAND, $data->getFee());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds new accessor methods for the `Transaction` properties. There is now a `toArray()` method to replace the array casting.

It also marks the current properties as deprecated, and they will be changed to `private` in version `3.0.0`.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
