### PR TITLE
Move factory methods to a Transaction factory

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace pxgamer\Arionum;
 
 use pxgamer\Arionum\Transaction\Version;
+use pxgamer\Arionum\Transaction\TransactionFactory;
 
 final class Transaction
 {
@@ -181,17 +182,14 @@ final class Transaction
      * @param  string  $message
      *
      * @return self
+     *
+     * @deprecated
+     *
+     * @see TransactionFactory::makemakeAliasSendInstance()
      */
     public static function makeAliasSendInstance(string $alias, float $value, string $message = ''): self
     {
-        $transaction = new self();
-
-        $transaction->setVersion(Version::ALIAS_SEND);
-        $transaction->setDestinationAddress($alias);
-        $transaction->setValue($value);
-        $transaction->setMessage($message);
-
-        return $transaction;
+        return TransactionFactory::makeAliasSendInstance($alias, $value, $message);
     }
 
     /**
@@ -201,18 +199,14 @@ final class Transaction
      * @param  string  $alias
      *
      * @return self
+     *
+     * @deprecated
+     *
+     * @see TransactionFactory::makeAliasSetInstance()
      */
     public static function makeAliasSetInstance(string $address, string $alias): self
     {
-        $transaction = new self();
-
-        $transaction->setVersion(Version::ALIAS_SET);
-        $transaction->setDestinationAddress($address);
-        $transaction->setValue(self::VALUE_ALIAS_SET);
-        $transaction->setFee(self::FEE_ALIAS_SET);
-        $transaction->setMessage($alias);
-
-        return $transaction;
+        return TransactionFactory::makeAliasSetInstance($address, $alias);
     }
 
     /**
@@ -222,18 +216,14 @@ final class Transaction
      * @param  string  $address
      *
      * @return self
+     *
+     * @deprecated
+     *
+     * @see TransactionFactory::makeMasternodeCreateInstance()
      */
     public static function makeMasternodeCreateInstance(string $ipAddress, string $address): self
     {
-        $transaction = new self();
-
-        $transaction->setVersion(Version::MASTERNODE_CREATE);
-        $transaction->setDestinationAddress($address);
-        $transaction->setValue(self::VALUE_MASTERNODE_CREATE);
-        $transaction->setFee(self::FEE_MASTERNODE_CREATE);
-        $transaction->setMessage($ipAddress);
-
-        return $transaction;
+        return TransactionFactory::makeMasternodeCreateInstance($ipAddress, $address);
     }
 
     /**
@@ -242,14 +232,14 @@ final class Transaction
      * @param  string  $address
      *
      * @return self
+     *
+     * @deprecated
+     *
+     * @see TransactionFactory::makeMasternodePauseInstance()
      */
     public static function makeMasternodePauseInstance(string $address): self
     {
-        $transaction = new self();
-
-        $transaction->setVersion(Version::MASTERNODE_PAUSE);
-
-        return self::setMasternodeCommandDefaults($address, $transaction);
+        return TransactionFactory::makeMasternodePauseInstance($address);
     }
 
     /**
@@ -258,14 +248,14 @@ final class Transaction
      * @param  string  $address
      *
      * @return self
+     *
+     * @deprecated
+     *
+     * @see TransactionFactory::makeMasternodeResumeInstance()
      */
     public static function makeMasternodeResumeInstance(string $address): self
     {
-        $transaction = new self();
-
-        $transaction->setVersion(Version::MASTERNODE_RESUME);
-
-        return self::setMasternodeCommandDefaults($address, $transaction);
+        return TransactionFactory::makeMasternodeResumeInstance($address);
     }
 
     /**
@@ -274,14 +264,14 @@ final class Transaction
      * @param  string  $address
      *
      * @return self
+     *
+     * @deprecated
+     *
+     * @see TransactionFactory::makeMasternodeReleaseInstance()
      */
     public static function makeMasternodeReleaseInstance(string $address): self
     {
-        $transaction = new self();
-
-        $transaction->setVersion(Version::MASTERNODE_RELEASE);
-
-        return self::setMasternodeCommandDefaults($address, $transaction);
+        return TransactionFactory::makeMasternodeReleaseInstance($address);
     }
 
     /**
@@ -390,23 +380,6 @@ final class Transaction
         $this->version = $version;
 
         return $this;
-    }
-
-    /**
-     * Set the default fee and value for masternode commands.
-     *
-     * @param  string  $address
-     * @param  self  $transaction
-     *
-     * @return self
-     */
-    private static function setMasternodeCommandDefaults(string $address, self $transaction): self
-    {
-        $transaction->setDestinationAddress($address);
-        $transaction->setValue(self::VALUE_MASTERNODE_COMMAND);
-        $transaction->setFee(self::FEE_MASTERNODE_COMMAND);
-
-        return $transaction;
     }
 
     public function getValue(): float

--- a/src/Transaction/TransactionFactory.php
+++ b/src/Transaction/TransactionFactory.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pxgamer\Arionum\Transaction;
+
+use pxgamer\Arionum\Transaction;
+
+final class TransactionFactory
+{
+    /**
+     * Retrieve a pre-populated Transaction instance for sending to an alias.
+     *
+     * @param  string  $alias
+     * @param  float  $value
+     * @param  string  $message
+     *
+     * @return Transaction
+     */
+    public static function makeAliasSendInstance(string $alias, float $value, string $message = ''): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->setVersion(Version::ALIAS_SEND);
+        $transaction->setDestinationAddress($alias);
+        $transaction->setValue($value);
+        $transaction->setMessage($message);
+
+        return $transaction;
+    }
+
+    /**
+     * Retrieve a pre-populated Transaction instance for setting an alias.
+     *
+     * @param  string  $address
+     * @param  string  $alias
+     *
+     * @return Transaction
+     */
+    public static function makeAliasSetInstance(string $address, string $alias): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->setVersion(Version::ALIAS_SET);
+        $transaction->setDestinationAddress($address);
+        $transaction->setValue(Transaction::VALUE_ALIAS_SET);
+        $transaction->setFee(Transaction::FEE_ALIAS_SET);
+        $transaction->setMessage($alias);
+
+        return $transaction;
+    }
+
+    /**
+     * Retrieve a pre-populated Transaction instance for creating a masternode.
+     *
+     * @param  string  $ipAddress
+     * @param  string  $address
+     *
+     * @return Transaction
+     */
+    public static function makeMasternodeCreateInstance(string $ipAddress, string $address): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->setVersion(Version::MASTERNODE_CREATE);
+        $transaction->setDestinationAddress($address);
+        $transaction->setValue(Transaction::VALUE_MASTERNODE_CREATE);
+        $transaction->setFee(Transaction::FEE_MASTERNODE_CREATE);
+        $transaction->setMessage($ipAddress);
+
+        return $transaction;
+    }
+
+    /**
+     * Retrieve a pre-populated Transaction instance for pausing a masternode.
+     *
+     * @param  string  $address
+     *
+     * @return Transaction
+     */
+    public static function makeMasternodePauseInstance(string $address): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->setVersion(Version::MASTERNODE_PAUSE);
+
+        return self::setMasternodeCommandDefaults($address, $transaction);
+    }
+
+    /**
+     * Retrieve a pre-populated Transaction instance for resuming a masternode.
+     *
+     * @param  string  $address
+     *
+     * @return Transaction
+     */
+    public static function makeMasternodeResumeInstance(string $address): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->setVersion(Version::MASTERNODE_RESUME);
+
+        return self::setMasternodeCommandDefaults($address, $transaction);
+    }
+
+    /**
+     * Retrieve a pre-populated Transaction instance for releasing a masternode.
+     *
+     * @param  string  $address
+     *
+     * @return Transaction
+     */
+    public static function makeMasternodeReleaseInstance(string $address): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->setVersion(Version::MASTERNODE_RELEASE);
+
+        return self::setMasternodeCommandDefaults($address, $transaction);
+    }
+
+    /**
+     * Set the default fee and value for masternode commands.
+     *
+     * @param  string  $address
+     * @param  Transaction  $transaction
+     *
+     * @return Transaction
+     */
+    private static function setMasternodeCommandDefaults(string $address, Transaction $transaction): Transaction
+    {
+        $transaction->setDestinationAddress($address);
+        $transaction->setValue(Transaction::VALUE_MASTERNODE_COMMAND);
+        $transaction->setFee(Transaction::FEE_MASTERNODE_COMMAND);
+
+        return $transaction;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This moves the existing Transaction factory methods from the `Transaction` class to a dedicated factory class. It also marks the existing methods as deprecated.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
