### PR TITLE
Add new 'change' methods to replace the setters

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -281,6 +281,96 @@ final class Transaction
      */
     public function setValue(float $value): self
     {
+        return $this->changeValue($value);
+    }
+
+    /**
+     * @param  float  $fee
+     *
+     * @return $this
+     */
+    public function setFee(float $fee): self
+    {
+        return $this->changeFee($fee);
+    }
+
+    /**
+     * @param  string  $destinationAddress
+     *
+     * @return $this
+     */
+    public function setDestinationAddress(string $destinationAddress): self
+    {
+        return $this->changeDestinationAddress($destinationAddress);
+    }
+
+    /**
+     * @param  string  $publicKey
+     *
+     * @return $this
+     */
+    public function setPublicKey(string $publicKey): self
+    {
+        return $this->changePublicKey($publicKey);
+    }
+
+    /**
+     * @param  string  $signature
+     *
+     * @return $this
+     */
+    public function setSignature(string $signature): self
+    {
+        return $this->changeSignature($signature);
+    }
+
+    /**
+     * @param  string  $privateKey
+     *
+     * @return $this
+     */
+    public function setPrivateKey(string $privateKey): self
+    {
+        return $this->changePrivateKey($privateKey);
+    }
+
+    /**
+     * @param  int  $date
+     *
+     * @return $this
+     */
+    public function setDate(int $date): self
+    {
+        return $this->changeDate($date);
+    }
+
+    /**
+     * @param  string  $message
+     *
+     * @return $this
+     */
+    public function setMessage(string $message): self
+    {
+        $this->changeMessage($message);
+    }
+
+    /**
+     * @param  int  $version
+     *
+     * @return $this
+     */
+    public function setVersion(int $version): self
+    {
+        $this->changeVersion($version);
+    }
+
+    /**
+     * @param  float  $value
+     *
+     * @return $this
+     */
+    public function changeValue(float $value): self
+    {
         $this->val = $value;
 
         return $this;
@@ -291,7 +381,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setFee(float $fee): self
+    public function changeFee(float $fee): self
     {
         $this->fee = $fee;
 
@@ -303,7 +393,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setDestinationAddress(string $destinationAddress): self
+    public function changeDestinationAddress(string $destinationAddress): self
     {
         $this->dst = $destinationAddress;
 
@@ -315,7 +405,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setPublicKey(string $publicKey): self
+    public function changePublicKey(string $publicKey): self
     {
         $this->public_key = $publicKey;
 
@@ -327,7 +417,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setSignature(string $signature): self
+    public function changeSignature(string $signature): self
     {
         $this->signature = $signature;
 
@@ -339,7 +429,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setPrivateKey(string $privateKey): self
+    public function changePrivateKey(string $privateKey): self
     {
         $this->private_key = $privateKey;
 
@@ -351,7 +441,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setDate(int $date): self
+    public function changeDate(int $date): self
     {
         $this->date = $date;
 
@@ -363,7 +453,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setMessage(string $message): self
+    public function changeMessage(string $message): self
     {
         $this->message = $message;
 
@@ -375,7 +465,7 @@ final class Transaction
      *
      * @return $this
      */
-    public function setVersion(int $version): self
+    public function changeVersion(int $version): self
     {
         $this->version = $version;
 

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -278,6 +278,10 @@ final class Transaction
      * @param  float  $value
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeValue()
      */
     public function setValue(float $value): self
     {
@@ -288,6 +292,10 @@ final class Transaction
      * @param  float  $fee
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeFee()
      */
     public function setFee(float $fee): self
     {
@@ -298,6 +306,10 @@ final class Transaction
      * @param  string  $destinationAddress
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeDestinationAddress()
      */
     public function setDestinationAddress(string $destinationAddress): self
     {
@@ -308,6 +320,10 @@ final class Transaction
      * @param  string  $publicKey
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changePublicKey()
      */
     public function setPublicKey(string $publicKey): self
     {
@@ -318,6 +334,10 @@ final class Transaction
      * @param  string  $signature
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeSignature()
      */
     public function setSignature(string $signature): self
     {
@@ -328,6 +348,10 @@ final class Transaction
      * @param  string  $privateKey
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changePrivateKey()
      */
     public function setPrivateKey(string $privateKey): self
     {
@@ -338,6 +362,10 @@ final class Transaction
      * @param  int  $date
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeDate()
      */
     public function setDate(int $date): self
     {
@@ -348,6 +376,10 @@ final class Transaction
      * @param  string  $message
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeMessage()
      */
     public function setMessage(string $message): self
     {
@@ -358,6 +390,10 @@ final class Transaction
      * @param  int  $version
      *
      * @return $this
+     *
+     * @deprecated
+     *
+     * @see changeVersion()
      */
     public function setVersion(int $version): self
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mark existing `set*` transaction methods as deprecated and move towards `change*` methods.

This also marks existing setters as deprecated.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
