### PR TITLE
Add new asset API methods

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -8,3 +8,17 @@
 // Returns an array of asset balances
 $arionum->getAssetBalance($address);
 ```
+
+#### Retrieve a list of registered assets
+
+```php
+// Returns an array of assets
+$arionum->getAssets();
+```
+
+#### Retrieve an asset by its id
+
+```php
+// Returns an array of assets
+$arionum->getAsset($assetId);
+```

--- a/src/Arionum.php
+++ b/src/Arionum.php
@@ -454,6 +454,25 @@ final class Arionum
         ]);
     }
 
+    /**
+     * Retrieve the asset orders for a specific address.
+     *
+     * @param  string  $address
+     * @param  string|null  $assetId
+     *
+     * @return array<stdClass>
+     *
+     * @throws GenericApiException
+     */
+    public function getAssetOrders(string $address, ?string $assetId = null): array
+    {
+        return $this->getJson([
+            'q' => 'asset-orders',
+            'account' => $address,
+            'asset' => $assetId,
+        ]);
+    }
+
     public function getNodeAddress(): string
     {
         return $this->nodeAddress;

--- a/src/Arionum.php
+++ b/src/Arionum.php
@@ -473,6 +473,37 @@ final class Arionum
         ]);
     }
 
+    /**
+     * Retrieve a list of assets.
+     *
+     * @return array<stdClass>
+     *
+     * @throws GenericApiException
+     */
+    public function getAssets(): array
+    {
+        return $this->getJson([
+            'q' => 'assets',
+        ]);
+    }
+
+    /**
+     * Retrieve a specific asset.
+     *
+     * @param  string|null  $assetId
+     *
+     * @return array<stdClass>
+     *
+     * @throws GenericApiException
+     */
+    public function getAsset(string $assetId): array
+    {
+        return $this->getJson([
+            'q' => 'assets',
+            'asset' => $assetId,
+        ]);
+    }
+
     public function getNodeAddress(): string
     {
         return $this->nodeAddress;

--- a/src/Laravel/ArionumFacade.php
+++ b/src/Laravel/ArionumFacade.php
@@ -34,6 +34,8 @@ use pxgamer\Arionum\Models\Transaction;
  * @method static bool checkAddress(string $address, ?string $publicKey = null)
  * @method static array getAssetBalance(string $address)
  * @method static array getAssetOrders(string $address, ?string $assetId)
+ * @method static array getAssets()
+ * @method static array getAsset(string $assetId)
  * @method static string getNodeAddress()
  *
  * @see Arionum

--- a/src/Laravel/ArionumFacade.php
+++ b/src/Laravel/ArionumFacade.php
@@ -33,6 +33,7 @@ use pxgamer\Arionum\Models\Transaction;
  * @method static stdClass getNodeInfo()
  * @method static bool checkAddress(string $address, ?string $publicKey = null)
  * @method static array getAssetBalance(string $address)
+ * @method static array getAssetOrders(string $address, ?string $assetId)
  * @method static string getNodeAddress()
  *
  * @see Arionum

--- a/tests/AssetTest.php
+++ b/tests/AssetTest.php
@@ -10,6 +10,8 @@ use pxgamer\Arionum\Exceptions\GenericApiException;
 
 final class AssetTest extends TestCase
 {
+    private const TEST_ASSET = 'aro';
+
     /**
      * @test
      * @return void
@@ -47,6 +49,46 @@ final class AssetTest extends TestCase
         $this->arionum = new Arionum(self::TEST_NODE, $client);
 
         $data = $this->arionum->getAssetOrders(self::TEST_ADDRESS);
+        $this->assertIsArray($data);
+        $this->assertEmpty($data);
+    }
+    /**
+     * @test
+     * @return void
+     * @throws GenericApiException
+     */
+    public function itCanRetrieveAssets(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], '{"data": [], "status": "ok"}'),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $this->arionum = new Arionum(self::TEST_NODE, $client);
+
+        $data = $this->arionum->getAssets();
+        $this->assertIsArray($data);
+        $this->assertEmpty($data);
+    }
+    /**
+     * @test
+     * @return void
+     * @throws GenericApiException
+     */
+    public function itCanRetrieveAnAsset(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], '{"data": [], "status": "ok"}'),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $this->arionum = new Arionum(self::TEST_NODE, $client);
+
+        $data = $this->arionum->getAsset(self::TEST_ASSET);
         $this->assertIsArray($data);
         $this->assertEmpty($data);
     }

--- a/tests/AssetTest.php
+++ b/tests/AssetTest.php
@@ -30,4 +30,24 @@ final class AssetTest extends TestCase
         $this->assertIsArray($data);
         $this->assertEmpty($data);
     }
+    /**
+     * @test
+     * @return void
+     * @throws GenericApiException
+     */
+    public function itCanRetrieveAssetOrders(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], '{"data": [], "status": "ok"}'),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $this->arionum = new Arionum(self::TEST_NODE, $client);
+
+        $data = $this->arionum->getAssetOrders(self::TEST_ADDRESS);
+        $this->assertIsArray($data);
+        $this->assertEmpty($data);
+    }
 }

--- a/tests/AssetTest.php
+++ b/tests/AssetTest.php
@@ -32,6 +32,7 @@ final class AssetTest extends TestCase
         $this->assertIsArray($data);
         $this->assertEmpty($data);
     }
+
     /**
      * @test
      * @return void
@@ -52,6 +53,7 @@ final class AssetTest extends TestCase
         $this->assertIsArray($data);
         $this->assertEmpty($data);
     }
+
     /**
      * @test
      * @return void
@@ -72,6 +74,7 @@ final class AssetTest extends TestCase
         $this->assertIsArray($data);
         $this->assertEmpty($data);
     }
+
     /**
      * @test
      * @return void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the new asset system methods for `getAssetOrders`, `getAssets`, and `getAsset`.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
