### PR TITLE
Add support for generating new accounts locally

### DIFF
--- a/docs/general.md
+++ b/docs/general.md
@@ -8,6 +8,12 @@
 $arionum->generateAccount();
 ```
 
+#### Generate a new account locally
+
+```php
+$arionum->generateLocalAccount();
+```
+
 #### Get an address from a public key
 
 ```php

--- a/src/Arionum.php
+++ b/src/Arionum.php
@@ -6,9 +6,11 @@ namespace pxgamer\Arionum;
 
 use stdClass;
 use GuzzleHttp\Client;
+use pxgamer\Arionum\Models\Account;
 use function GuzzleHttp\json_decode;
 use pxgamer\Arionum\Models\Transaction;
 use pxgamer\Arionum\Exceptions\GenericApiException;
+use pxgamer\Arionum\Exceptions\GenericLocalException;
 
 final class Arionum
 {
@@ -502,6 +504,18 @@ final class Arionum
             'q' => 'assets',
             'asset' => $assetId,
         ]);
+    }
+
+    /**
+     * Generate a new public/private key pair and return these with the address.
+     *
+     * @return Account
+     *
+     * @throws GenericLocalException
+     */
+    public function generateLocalAccount(): Account
+    {
+        return Account::make();
     }
 
     public function getNodeAddress(): string

--- a/src/Exceptions/GenericLocalException.php
+++ b/src/Exceptions/GenericLocalException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pxgamer\Arionum\Exceptions;
+
+final class GenericLocalException extends ArionumException
+{
+    public static function failedToGenerateLocalAccountKeyPair(): self
+    {
+        return new self('Failed to generate a local account key pair');
+    }
+}

--- a/src/Helpers/Key.php
+++ b/src/Helpers/Key.php
@@ -32,4 +32,28 @@ final class Key
             sprintf("%s\n%s\n%s", self::EC_PRIVATE_START, $keyData, self::EC_PRIVATE_END) :
             sprintf("%s\n%s\n%s", self::EC_PUBLIC_START, $keyData, self::EC_PUBLIC_END);
     }
+
+    /**
+     * @param  string  $data
+     *
+     * @return string
+     *
+     * @throws Exception
+     *
+     * @internal
+     */
+    public static function pemToBase58(string $data): string
+    {
+        return (new Base58())->encode(
+            base64_decode(
+                str_replace([
+                    '-----BEGIN PUBLIC KEY-----',
+                    '-----END PUBLIC KEY-----',
+                    '-----BEGIN EC PRIVATE KEY-----',
+                    '-----END EC PRIVATE KEY-----',
+                    "\n",
+                ], '', $data)
+            )
+        );
+    }
 }

--- a/src/Laravel/ArionumFacade.php
+++ b/src/Laravel/ArionumFacade.php
@@ -4,6 +4,7 @@ namespace pxgamer\Arionum\Laravel;
 
 use stdClass;
 use pxgamer\Arionum\Arionum;
+use pxgamer\Arionum\Models\Account;
 use Illuminate\Support\Facades\Facade;
 use pxgamer\Arionum\Models\Transaction;
 
@@ -19,6 +20,7 @@ use pxgamer\Arionum\Models\Transaction;
  * @method static stdClass getTransaction(string $transactionId)
  * @method static string getPublicKey(string $address)
  * @method static stdClass generateAccount()
+ * @method static Account generateLocalAccount()
  * @method static stdClass getCurrentBlock()
  * @method static stdClass getBlock(int $height)
  * @method static array getBlockTransactions(string $blockId)

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace pxgamer\Arionum\Models;
+
+use Exception;
+use StephenHill\Base58;
+use pxgamer\Arionum\Helpers\Key;
+use pxgamer\Arionum\Exceptions\GenericLocalException;
+
+final class Account
+{
+    private const CURVE_NAME = 'secp256k1';
+    private const PRIVATE_KEY_TYPE = OPENSSL_KEYTYPE_EC;
+
+    /** @var string */
+    private $publicKey;
+    /** @var string */
+    private $privateKey;
+
+    public function __construct(string $publicKey, string $privateKey)
+    {
+        $this->publicKey = $publicKey;
+        $this->privateKey = $privateKey;
+    }
+
+    /**
+     * @return self
+     *
+     * @throws GenericLocalException
+     */
+    public static function make(): self
+    {
+        try {
+            // Using secp256k1 curve for ECDSA
+            $args = [
+                'curve_name' => self::CURVE_NAME,
+                'private_key_type' => self::PRIVATE_KEY_TYPE,
+            ];
+
+            // Generates a new key pair
+            $keyPair = openssl_pkey_new($args);
+
+            // Exports the private key encoded as PEM
+            openssl_pkey_export($keyPair, $privateKeyPem);
+
+            // Converts the PEM to a base58 format
+            $privateKey = Key::pemToBase58($privateKeyPem);
+
+            // Exports the private key encoded as PEM
+            $pub = openssl_pkey_get_details($keyPair);
+
+            // Converts the PEM to a base58 format
+            $publicKey = Key::pemToBase58($pub['key']);
+        } catch (Exception $exception) {
+            throw GenericLocalException::failedToGenerateLocalAccountKeyPair();
+        }
+
+        return new self($publicKey, $privateKey);
+    }
+
+    public function getAddress(): string
+    {
+        $hash = $this->publicKey;
+
+        // Hashes 9 times in sha512 (binary) and encodes in base58
+        for ($i = 0; $i < 9; $i++) {
+            $hash = hash('sha512', $hash, true);
+        }
+
+        return (new Base58())->encode($hash);
+    }
+
+    public function getPublicKey(): string
+    {
+        return $this->publicKey;
+    }
+
+    public function getPrivateKey(): string
+    {
+        return $this->privateKey;
+    }
+}

--- a/tests/LocalAccountTest.php
+++ b/tests/LocalAccountTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace pxgamer\Arionum;
+
+use pxgamer\Arionum\Models\Account;
+
+final class LocalAccountTest extends TestCase
+{
+    /** @test */
+    public function itCanGenerateALocalAccount(): void
+    {
+        $account = Account::make();
+
+        $this->assertStringStartsWith('PZ', $account->getPublicKey());
+        $this->assertStringStartsWith('Lz', $account->getPrivateKey());
+    }
+
+    /** @test */
+    public function itCanGenerateALocalAccountViaTheHelper(): void
+    {
+        $account = $this->arionum->generateLocalAccount();
+
+        $this->assertStringStartsWith('PZ', $account->getPublicKey());
+        $this->assertStringStartsWith('Lz', $account->getPrivateKey());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for generating new accounts locally (rather than requesting from the node).

Returns an instance of [`pxgamer\Arionum\Models\Account`](https://github.com/pxgamer/arionum-php/blob/735309959f62d0a187138cca8cde8597658ff64a/src/Models/Account.php) with the key pair prefilled.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
