### PR TITLE
Update generateAccount method to return Account

### DIFF
--- a/src/Arionum.php
+++ b/src/Arionum.php
@@ -211,15 +211,17 @@ final class Arionum
     /**
      * Generate a new public/private key pair and return these with the address.
      *
-     * @return stdClass
+     * @return Account
      *
      * @throws GenericApiException
      */
-    public function generateAccount(): stdClass
+    public function generateAccount(): Account
     {
-        return $this->getJson([
+        $generatedAccount = $this->getJson([
             'q' => 'generateAccount',
         ]);
+
+        return new Account($generatedAccount->public_key, $generatedAccount->private_key);
     }
 
     /**

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -16,9 +16,8 @@ final class AccountTest extends TestCase
     public function itGeneratesANewAccount(): void
     {
         $data = $this->arionum->generateAccount();
-        $this->assertObjectHasAttribute('address', $data);
-        $this->assertObjectHasAttribute('public_key', $data);
-        $this->assertObjectHasAttribute('private_key', $data);
+        $this->assertStringStartsWith('PZ', $data->getPublicKey());
+        $this->assertStringStartsWith('Lz', $data->getPrivateKey());
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the `generateAccount()` method to return an instance of the `Account` model.

When using the `generateAccount()` method, you will now need to use the [methods available on that class](https://github.com/pxgamer/arionum-php/blob/12b22f96b45a8c1fd1118549d8701dce6c06dfea/src/Models/Account.php#L61-L81) instead of directly accessing the public `stdClass` properties.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
